### PR TITLE
feat: add support for multiple http requests in single file

### DIFF
--- a/hitt-cli/src/main.rs
+++ b/hitt-cli/src/main.rs
@@ -35,7 +35,7 @@ async fn main() -> anyhow::Result<(), Box<dyn std::error::Error>> {
 
         let fcontent = get_file_content(path).await?;
 
-        for req in hitt_parser::parse_requests(fcontent).unwrap() {
+        for req in hitt_parser::parse_requests(&fcontent).unwrap() {
             let result = send_request(req).await?;
 
             println!("{} {}", result.status(), result.url());

--- a/tests/multiple-requests.http
+++ b/tests/multiple-requests.http
@@ -1,0 +1,12 @@
+GET https://mhouge.dk/ HTTP/1.1
+
+###
+
+GET https://mhouge.dk/ HTTP/2
+
+###
+
+GET https://mhouge.dk/ HTTP/3
+
+###
+


### PR DESCRIPTION
The primary aim of this PR is to add support for multiple requests in a single file. Merging this will close #5.

`###` is used to declare new requests:

```http
GET https://localhost:7220/weatherforecast

###

GET https://localhost:7220/weatherforecast?date=2023-05-11&location=98006

###

GET https://localhost:7220/weatherforecast HTTP/3

###

```

This PR also adds support for adding comments to the file by either starting the line with `#` or `//` (closes #4 )
