### PR TITLE
feat: parse request http version

### DIFF
--- a/hitt-cli/Cargo.toml
+++ b/hitt-cli/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.75"
 crossterm = { version = "0.27.0", features = ["event-stream"] }
-hitt-parser ={ path ="../hitt-parser" }
+hitt-parser = { path = "../hitt-parser" }
 reqwest = "0.11.20"
 serde = "1.0.188"
 tokio = { version = "1.32.0", features = ["full"] }

--- a/hitt-cli/src/main.rs
+++ b/hitt-cli/src/main.rs
@@ -11,6 +11,7 @@ async fn send_request(input: HittRequest) -> Result<reqwest::Response, reqwest::
         .request(input.method, input.uri.to_string())
         .headers(input.headers)
         .body(input.body.unwrap_or_default())
+        .version(input.http_version.unwrap_or(reqwest::Version::HTTP_11))
         .build()?;
 
     client.execute(req).await

--- a/tests/multiple-requests.http
+++ b/tests/multiple-requests.http
@@ -2,11 +2,4 @@ GET https://mhouge.dk/ HTTP/1.1
 
 ###
 
-GET https://mhouge.dk/ HTTP/2
-
-###
-
-GET https://mhouge.dk/ HTTP/3
-
-###
-
+GET https://mhouge.dk/ HTTP/1.1


### PR DESCRIPTION
Adds support for request http version parsing. 

Please not that only `HTTP/1.0` and `HTTP/1.1` is currently supported by `reqwest`. 

Closes #7 