### PR TITLE
fix(cli): hide --vim argument

### DIFF
--- a/hitt-cli/src/config/mod.rs
+++ b/hitt-cli/src/config/mod.rs
@@ -41,7 +41,7 @@ pub(crate) struct RunCommandArguments {
     #[arg(long, short, default_value_t = false)]
     pub(crate) recursive: bool,
 
-    #[arg(long, default_value_t = false)]
+    #[arg(long, default_value_t = false, hide = true)]
     pub(crate) vim: bool,
 }
 


### PR DESCRIPTION
The `--vim` argument is only meant for internal usage and should not be shown in `--help`.