### PR TITLE
feat: implement support for variables

### DIFF
--- a/examples/get-with-variable.http
+++ b/examples/get-with-variable.http
@@ -1,0 +1,4 @@
+@host = https://api.goout.dk
+@query = 1234
+
+GET {{host}}?q={{query}}

--- a/hitt-parser/Cargo.toml
+++ b/hitt-parser/Cargo.toml
@@ -14,3 +14,6 @@ categories = []
 
 [dependencies]
 http = { workspace = true }
+
+[dev-dependencies]
+once_cell = { version = "1.19.0" }

--- a/hitt-parser/src/error/mod.rs
+++ b/hitt-parser/src/error/mod.rs
@@ -6,6 +6,7 @@ pub enum RequestParseError {
     MissingUri,
     InvalidHeaderName(String),
     InvalidHeaderValue(String),
+    VariableNotFound(String),
 }
 
 impl core::fmt::Display for RequestParseError {
@@ -18,6 +19,7 @@ impl core::fmt::Display for RequestParseError {
             Self::MissingUri => write!(f, "missing uri"),
             Self::InvalidHeaderName(name) => write!(f, "invalid header name '{name}'"),
             Self::InvalidHeaderValue(value) => write!(f, "invalid header value '{value}'"),
+            Self::VariableNotFound(value) => write!(f, "variable '{value}' was used, but not set"),
         }
     }
 }

--- a/hitt-parser/src/header/mod.rs
+++ b/hitt-parser/src/header/mod.rs
@@ -45,7 +45,7 @@ pub fn parse_header(
                         line.next();
                     }
                 } else {
-                    panic!("unable to find value for variable '{var}'");
+                    return Err(RequestParseError::VariableNotFound(var));
                 }
             } else {
                 if is_key {
@@ -86,7 +86,7 @@ mod test_parse_header {
 
     #[test]
     fn it_should_return_valid_headers() {
-        for i in 0..1337 {
+        for i in i8::MIN..i8::MAX {
             let line = format!("header{i}: value{i}");
 
             let result = parse_header(&mut to_enum_chars(&line), &EMPTY_VARS)
@@ -120,7 +120,7 @@ mod test_parse_header {
         let close = "}}";
         let mut extra_spaces = String::new();
 
-        for i in 0..1337 {
+        for i in i8::MIN..i8::MAX {
             let key = format!("key{i}");
             let value = format!("value{i}");
 

--- a/hitt-parser/src/header/mod.rs
+++ b/hitt-parser/src/header/mod.rs
@@ -86,7 +86,7 @@ mod test_parse_header {
 
     #[test]
     fn it_should_return_valid_headers() {
-        for i in 0..10 {
+        for i in 0..1337 {
             let line = format!("header{i}: value{i}");
 
             let result = parse_header(&mut to_enum_chars(&line), &EMPTY_VARS)
@@ -120,7 +120,7 @@ mod test_parse_header {
         let close = "}}";
         let mut extra_spaces = String::new();
 
-        for i in 0..1000 {
+        for i in 0..1337 {
             let key = format!("key{i}");
             let value = format!("value{i}");
 

--- a/hitt-parser/src/header/mod.rs
+++ b/hitt-parser/src/header/mod.rs
@@ -3,7 +3,7 @@ use core::str::FromStr;
 use crate::{error::RequestParseError, RequestToken};
 
 #[derive(Debug)]
-pub(super) struct HeaderToken {
+pub struct HeaderToken {
     pub(super) key: http::HeaderName,
     pub(super) value: http::HeaderValue,
 }
@@ -16,7 +16,7 @@ impl From<HeaderToken> for RequestToken {
 }
 
 #[inline]
-pub(super) fn parse_header(
+pub fn parse_header(
     line: core::iter::Enumerate<core::str::Chars>,
 ) -> Result<Option<HeaderToken>, RequestParseError> {
     let mut key = String::new();

--- a/hitt-parser/src/lib.rs
+++ b/hitt-parser/src/lib.rs
@@ -83,7 +83,7 @@ fn tokenize(buffer: &str) -> Result<Vec<RequestToken>, RequestParseError> {
             ParserMode::Request => {
                 if !trimmed_line.is_empty() {
                     let mut chrs = to_enum_chars(line);
-                    let method = parse_method_input(&mut chrs)?;
+                    let method = parse_method_input(&mut chrs, &vars)?;
 
                     tokens.push(RequestToken::Method(method));
 
@@ -149,7 +149,13 @@ mod test_tokenize {
                 RequestToken::Header(header_token) => {
                     assert_eq!(header1_key, header_token.key.to_string());
 
-                    assert_eq!(header1_value, header_token.value.to_str().unwrap());
+                    assert_eq!(
+                        header1_value,
+                        header_token
+                            .value
+                            .to_str()
+                            .expect("value to be a valid str")
+                    );
                 }
 
                 RequestToken::Body(body_token) => {
@@ -348,7 +354,7 @@ mod test_parse_requests {
 
             assert!(parsed_requests.len() == 1);
 
-            let first_request = &parsed_requests[0];
+            let first_request = parsed_requests.first().expect("it to be a request");
 
             assert_eq!(expected_method, first_request.method);
 

--- a/hitt-parser/src/lib.rs
+++ b/hitt-parser/src/lib.rs
@@ -82,7 +82,7 @@ fn tokenize(buffer: &str) -> Result<Vec<RequestToken>, RequestParseError> {
         match parser_mode {
             ParserMode::Request => {
                 if !trimmed_line.is_empty() {
-                    let mut chrs = to_enum_chars(line);
+                    let mut chrs = to_enum_chars(trimmed_line);
                     let method = parse_method_input(&mut chrs, &vars)?;
 
                     tokens.push(RequestToken::Method(method));
@@ -100,9 +100,11 @@ fn tokenize(buffer: &str) -> Result<Vec<RequestToken>, RequestParseError> {
             }
 
             ParserMode::Headers => {
-                if line.trim().is_empty() {
+                if trimmed_line.is_empty() {
                     parser_mode = ParserMode::Body;
-                } else if let Some(header_token) = parse_header(&mut to_enum_chars(line), &vars)? {
+                } else if let Some(header_token) =
+                    parse_header(&mut to_enum_chars(trimmed_line), &vars)?
+                {
                     tokens.push(RequestToken::Header(header_token));
                 }
             }

--- a/hitt-parser/src/lib.rs
+++ b/hitt-parser/src/lib.rs
@@ -12,6 +12,7 @@ mod uri;
 mod variables;
 mod version;
 
+#[derive(Copy, Clone)]
 enum ParserMode {
     Request,
     Headers,
@@ -377,7 +378,7 @@ mod test_parse_requests {
 
         assert!(result.len() == 1);
 
-        let request = &result[0];
+        let request = result.first().expect("request len to be 1");
 
         assert_eq!(method_input, request.method.as_str());
 
@@ -394,7 +395,10 @@ mod test_parse_requests {
             .get(header1_key)
             .expect("header1_key to exist");
 
-        assert_eq!(header1_value, header1_output.to_str().unwrap());
+        assert_eq!(
+            header1_value,
+            header1_output.to_str().expect("it to be a valid header")
+        );
 
         assert!(request.http_version.is_none());
     }

--- a/hitt-parser/src/lib.rs
+++ b/hitt-parser/src/lib.rs
@@ -96,7 +96,9 @@ fn tokenize(buffer: &str) -> Result<Vec<RequestToken>, RequestParseError> {
             ParserMode::Headers => {
                 if line.trim().is_empty() {
                     parser_mode = ParserMode::Body;
-                } else if let Some(header_token) = parse_header(line.chars().enumerate())? {
+                } else if let Some(header_token) =
+                    parse_header(&mut line.chars().enumerate(), &vars)?
+                {
                     tokens.push(RequestToken::Header(header_token));
                 }
             }
@@ -163,7 +165,7 @@ mod test_tokenize {
 
     #[test]
     fn it_should_be_able_to_parse_multiple_requests() {
-        let input = r"
+        let input = "
 GET https://mhouge.dk/ HTTP/0.9
 x-test-header: test value
 
@@ -396,7 +398,7 @@ mod test_parse_requests {
 
     #[test]
     fn it_should_be_able_to_parse_multiple_requests() {
-        let input = r"
+        let input = "
 GET https://mhouge.dk/ HTTP/0.9
 
 ###

--- a/hitt-parser/src/lib.rs
+++ b/hitt-parser/src/lib.rs
@@ -35,7 +35,7 @@ fn tokenize(buffer: &str) -> Result<Vec<RequestToken>, RequestParseError> {
 
     let mut body_parts: Vec<&str> = Vec::new();
 
-    let mut variables = std::collections::HashMap::new();
+    let mut vars = std::collections::HashMap::new();
 
     for line in buffer.lines() {
         let trimmed_line = line.trim();
@@ -68,7 +68,7 @@ fn tokenize(buffer: &str) -> Result<Vec<RequestToken>, RequestParseError> {
             chrs.next();
 
             if let Some((name, value)) = parse_variable_declaration(&mut chrs) {
-                variables.insert(name, value);
+                vars.insert(name, value);
                 continue;
             }
         }
@@ -81,7 +81,7 @@ fn tokenize(buffer: &str) -> Result<Vec<RequestToken>, RequestParseError> {
 
                     tokens.push(RequestToken::Method(method));
 
-                    let uri = parse_uri_input(&mut chrs)?;
+                    let uri = parse_uri_input(&mut chrs, &vars)?;
 
                     tokens.push(RequestToken::Uri(uri));
 
@@ -136,9 +136,9 @@ mod test_tokenize {
 
         for token in tokens {
             match token {
-                RequestToken::Uri(uri_token) => assert_eq!(uri_input, uri_token.to_string(),),
+                RequestToken::Uri(uri_token) => assert_eq!(uri_input, uri_token.to_string()),
                 RequestToken::Method(method_token) => {
-                    assert_eq!(method_input, method_token.as_str())
+                    assert_eq!(method_input, method_token.as_str());
                 }
                 RequestToken::Header(header_token) => {
                     assert_eq!(header1_key, header_token.key.to_string());
@@ -155,7 +155,7 @@ mod test_tokenize {
                 }
 
                 RequestToken::HttpVersion(version_token) => {
-                    assert_eq!(version_token, http::version::Version::HTTP_2)
+                    assert_eq!(version_token, http::version::Version::HTTP_2);
                 }
             }
         }
@@ -204,7 +204,7 @@ x-test-header: test value
                 }
 
                 RequestToken::Uri(uri_token) => {
-                    assert_eq!("https://mhouge.dk/", uri_token.to_string())
+                    assert_eq!("https://mhouge.dk/", uri_token.to_string());
                 }
 
                 RequestToken::Header(header_token) => {
@@ -334,7 +334,7 @@ mod test_parse_requests {
     fn it_should_parse_http_method_correctly() {
         let url = "https://mhouge.dk";
 
-        for method in HTTP_METHODS.iter() {
+        for method in &HTTP_METHODS {
             let expected_method = http::Method::from_str(method).expect("m is a valid method");
 
             let parsed_requests =

--- a/hitt-parser/src/lib.rs
+++ b/hitt-parser/src/lib.rs
@@ -28,6 +28,11 @@ enum RequestToken {
 }
 
 #[inline]
+pub fn to_enum_chars(input: &str) -> core::iter::Enumerate<core::str::Chars> {
+    input.chars().enumerate()
+}
+
+#[inline]
 fn tokenize(buffer: &str) -> Result<Vec<RequestToken>, RequestParseError> {
     let mut tokens: Vec<RequestToken> = Vec::new();
 
@@ -62,7 +67,7 @@ fn tokenize(buffer: &str) -> Result<Vec<RequestToken>, RequestParseError> {
         }
 
         if trimmed_line.starts_with('@') {
-            let mut chrs = trimmed_line.chars().enumerate();
+            let mut chrs = to_enum_chars(trimmed_line);
 
             // move forward once since we don't care about the '@'
             chrs.next();
@@ -76,7 +81,7 @@ fn tokenize(buffer: &str) -> Result<Vec<RequestToken>, RequestParseError> {
         match parser_mode {
             ParserMode::Request => {
                 if !trimmed_line.is_empty() {
-                    let mut chrs = line.chars().enumerate();
+                    let mut chrs = to_enum_chars(line);
                     let method = parse_method_input(&mut chrs)?;
 
                     tokens.push(RequestToken::Method(method));
@@ -85,7 +90,7 @@ fn tokenize(buffer: &str) -> Result<Vec<RequestToken>, RequestParseError> {
 
                     tokens.push(RequestToken::Uri(uri));
 
-                    if let Some(http_version) = parse_http_version(&mut chrs) {
+                    if let Some(http_version) = parse_http_version(&mut chrs, &vars) {
                         tokens.push(RequestToken::HttpVersion(http_version));
                     }
 
@@ -96,9 +101,7 @@ fn tokenize(buffer: &str) -> Result<Vec<RequestToken>, RequestParseError> {
             ParserMode::Headers => {
                 if line.trim().is_empty() {
                     parser_mode = ParserMode::Body;
-                } else if let Some(header_token) =
-                    parse_header(&mut line.chars().enumerate(), &vars)?
-                {
+                } else if let Some(header_token) = parse_header(&mut to_enum_chars(line), &vars)? {
                     tokens.push(RequestToken::Header(header_token));
                 }
             }

--- a/hitt-parser/src/lib.rs
+++ b/hitt-parser/src/lib.rs
@@ -29,7 +29,7 @@ enum RequestToken {
 }
 
 #[inline]
-pub fn to_enum_chars(input: &str) -> core::iter::Enumerate<core::str::Chars> {
+fn to_enum_chars(input: &str) -> core::iter::Enumerate<core::str::Chars> {
     input.chars().enumerate()
 }
 

--- a/hitt-parser/src/lib.rs
+++ b/hitt-parser/src/lib.rs
@@ -67,20 +67,20 @@ fn tokenize(buffer: &str) -> Result<Vec<RequestToken>, RequestParseError> {
             continue;
         }
 
-        if trimmed_line.starts_with('@') {
-            let mut chrs = to_enum_chars(trimmed_line);
-
-            // move forward once since we don't care about the '@'
-            chrs.next();
-
-            if let Some((name, value)) = parse_variable_declaration(&mut chrs) {
-                vars.insert(name, value);
-                continue;
-            }
-        }
-
         match parser_mode {
             ParserMode::Request => {
+                if trimmed_line.starts_with('@') {
+                    let mut chrs = to_enum_chars(trimmed_line);
+
+                    // move forward once since we don't care about the '@'
+                    chrs.next();
+
+                    if let Some((name, value)) = parse_variable_declaration(&mut chrs) {
+                        vars.insert(name, value);
+                        continue;
+                    }
+                }
+
                 if !trimmed_line.is_empty() {
                     let mut chrs = to_enum_chars(trimmed_line);
                     let method = parse_method_input(&mut chrs, &vars)?;

--- a/hitt-parser/src/method/mod.rs
+++ b/hitt-parser/src/method/mod.rs
@@ -1,6 +1,6 @@
 use core::str::FromStr;
 
-use crate::{error::RequestParseError, RequestToken};
+use crate::{error::RequestParseError, variables::parse_variable, RequestToken};
 
 impl From<http::method::Method> for RequestToken {
     #[inline]
@@ -12,15 +12,32 @@ impl From<http::method::Method> for RequestToken {
 #[inline]
 pub fn parse_method_input(
     chars: &mut core::iter::Enumerate<core::str::Chars>,
+    vars: &std::collections::HashMap<String, String>,
 ) -> Result<http::method::Method, RequestParseError> {
     let mut method = String::new();
 
-    for (_i, ch) in chars {
+    while let Some((_, ch)) = chars.next() {
         if ch.is_whitespace() {
             if !method.is_empty() {
                 break;
             }
-        } else {
+        } else if ch == '{' {
+            // FIXME: remove clone
+            if let Some((var, jumps)) = parse_variable(&mut chars.clone()) {
+                if let Some(var_value) = vars.get(&var) {
+                    method.push_str(var_value);
+
+                    for _ in 0..jumps {
+                        chars.next();
+                    }
+
+                    continue;
+                } else {
+                    return Err(RequestParseError::VariableNotFound(var));
+                }
+            }
+        }
+        {
             method.push(ch);
         }
     }
@@ -33,7 +50,14 @@ pub fn parse_method_input(
 
 #[cfg(test)]
 mod test_parse_method_input {
+    use core::str::FromStr;
+
+    use once_cell::sync::Lazy;
+
     use crate::{method::parse_method_input, to_enum_chars};
+
+    static EMPTY_VARS: Lazy<std::collections::HashMap<String, String>> =
+        Lazy::new(std::collections::HashMap::new);
 
     const HTTP_METHODS: [&str; 9] = [
         "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "CONNECT", "TRACE",
@@ -44,7 +68,7 @@ mod test_parse_method_input {
         for method_input in HTTP_METHODS {
             let input = format!("{method_input} https://mhouge.dk HTTP/2");
 
-            let parsed_method = parse_method_input(&mut to_enum_chars(&input))
+            let parsed_method = parse_method_input(&mut to_enum_chars(&input), &EMPTY_VARS)
                 .expect("it should return a valid method");
 
             assert_eq!(method_input, parsed_method.as_str());
@@ -56,10 +80,34 @@ mod test_parse_method_input {
         for method_input in HTTP_METHODS {
             let input = format!("{} https://mhouge.dk HTTP/2", method_input.to_lowercase());
 
-            let parsed_method = parse_method_input(&mut to_enum_chars(&input))
+            let parsed_method = parse_method_input(&mut to_enum_chars(&input), &EMPTY_VARS)
                 .expect("it should return a valid method");
 
             assert_eq!(method_input, parsed_method.as_str());
+        }
+    }
+
+    #[test]
+    fn it_should_support_variables() {
+        let mut vars = std::collections::HashMap::new();
+
+        for method in HTTP_METHODS {
+            vars.insert("method".to_owned(), method.to_owned());
+
+            let expected_method =
+                http::method::Method::from_str(method).expect("it should return a valid method");
+
+            assert_eq!(
+                expected_method,
+                parse_method_input(&mut to_enum_chars("{{method}}"), &vars)
+                    .expect("it should return a valid method")
+            );
+
+            assert_eq!(
+                expected_method,
+                parse_method_input(&mut to_enum_chars("{{  method  }}"), &vars)
+                    .expect("it should return a valid method")
+            );
         }
     }
 }

--- a/hitt-parser/src/method/mod.rs
+++ b/hitt-parser/src/method/mod.rs
@@ -32,12 +32,13 @@ pub fn parse_method_input(
                     }
 
                     continue;
-                } else {
-                    return Err(RequestParseError::VariableNotFound(var));
                 }
+
+                return Err(RequestParseError::VariableNotFound(var));
             }
-        }
-        {
+
+            method.push(ch);
+        } else {
             method.push(ch);
         }
     }
@@ -90,6 +91,11 @@ mod test_parse_method_input {
     #[test]
     fn it_should_support_variables() {
         let mut vars = std::collections::HashMap::new();
+
+        parse_method_input(&mut to_enum_chars("{method"), &EMPTY_VARS).expect_err("invalid method");
+
+        parse_method_input(&mut to_enum_chars("{method}"), &EMPTY_VARS)
+            .expect_err("invalid method");
 
         for method in HTTP_METHODS {
             vars.insert("method".to_owned(), method.to_owned());

--- a/hitt-parser/src/method/mod.rs
+++ b/hitt-parser/src/method/mod.rs
@@ -33,7 +33,7 @@ pub fn parse_method_input(
 
 #[cfg(test)]
 mod test_parse_method_input {
-    use crate::method::parse_method_input;
+    use crate::{method::parse_method_input, to_enum_chars};
 
     const HTTP_METHODS: [&str; 9] = [
         "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "CONNECT", "TRACE",
@@ -44,7 +44,7 @@ mod test_parse_method_input {
         for method_input in HTTP_METHODS {
             let input = format!("{method_input} https://mhouge.dk HTTP/2");
 
-            let parsed_method = parse_method_input(&mut input.chars().enumerate())
+            let parsed_method = parse_method_input(&mut to_enum_chars(&input))
                 .expect("it should return a valid method");
 
             assert_eq!(method_input, parsed_method.as_str());
@@ -56,7 +56,7 @@ mod test_parse_method_input {
         for method_input in HTTP_METHODS {
             let input = format!("{} https://mhouge.dk HTTP/2", method_input.to_lowercase());
 
-            let parsed_method = parse_method_input(&mut input.chars().enumerate())
+            let parsed_method = parse_method_input(&mut to_enum_chars(&input))
                 .expect("it should return a valid method");
 
             assert_eq!(method_input, parsed_method.as_str());

--- a/hitt-parser/src/method/mod.rs
+++ b/hitt-parser/src/method/mod.rs
@@ -10,7 +10,7 @@ impl From<http::method::Method> for RequestToken {
 }
 
 #[inline]
-pub(super) fn parse_method_input(
+pub fn parse_method_input(
     chars: &mut core::iter::Enumerate<core::str::Chars>,
 ) -> Result<http::method::Method, RequestParseError> {
     let mut method = String::new();

--- a/hitt-parser/src/uri/mod.rs
+++ b/hitt-parser/src/uri/mod.rs
@@ -100,7 +100,7 @@ mod test_parse_uri_input {
     fn it_should_support_query_paramers() {
         let input_uri = "https://mhouge.dk/";
 
-        for i in 0..10 {
+        for i in 0..1337 {
             let input = format!("{input_uri}?key{i}=value{i}");
 
             let result = parse_uri_input(&mut to_enum_chars(&input), &EMPTY_VARS)
@@ -119,7 +119,7 @@ mod test_parse_uri_input {
         let variable_open = "{{";
         let variable_close = "}}";
 
-        for i in 0..10 {
+        for i in 0..1337 {
             vars.insert(format!("i{i}"), i.to_string());
 
             let input = format!("{input_uri}?key={variable_open}i{i}{variable_close}");

--- a/hitt-parser/src/uri/mod.rs
+++ b/hitt-parser/src/uri/mod.rs
@@ -100,7 +100,7 @@ mod test_parse_uri_input {
     fn it_should_support_query_paramers() {
         let input_uri = "https://mhouge.dk/";
 
-        for i in 0..1337 {
+        for i in i8::MIN..i8::MAX {
             let input = format!("{input_uri}?key{i}=value{i}");
 
             let result = parse_uri_input(&mut to_enum_chars(&input), &EMPTY_VARS)
@@ -119,7 +119,7 @@ mod test_parse_uri_input {
         let variable_open = "{{";
         let variable_close = "}}";
 
-        for i in 0..1337 {
+        for i in i8::MIN..i8::MAX {
             vars.insert(format!("i{i}"), i.to_string());
 
             let input = format!("{input_uri}?key={variable_open}i{i}{variable_close}");

--- a/hitt-parser/src/uri/mod.rs
+++ b/hitt-parser/src/uri/mod.rs
@@ -15,12 +15,14 @@ pub fn parse_uri_input(
     vars: &std::collections::HashMap<String, String>,
 ) -> Result<http::uri::Uri, RequestParseError> {
     let mut uri = String::new();
+
     while let Some((_, ch)) = chars.next() {
         if ch.is_whitespace() {
             if !uri.is_empty() {
                 break;
             }
         } else if ch == '{' {
+            // FIXME: remove clone
             if let Some((var, jumps)) = parse_variable(&mut chars.clone()) {
                 if let Some(var_value) = vars.get(&var) {
                     uri.push_str(var_value);
@@ -29,8 +31,7 @@ pub fn parse_uri_input(
                         chars.next();
                     }
                 } else {
-                    panic!("unable to find variable {var}");
-                    // TODO: raise error
+                    return Err(RequestParseError::VariableNotFound(var));
                 }
             } else {
                 uri.push(ch);
@@ -45,7 +46,6 @@ pub fn parse_uri_input(
 
 #[cfg(test)]
 mod test_parse_uri_input {
-
     use crate::uri::parse_uri_input;
 
     #[test]
@@ -150,7 +150,7 @@ mod test_parse_uri_input {
             )
             .expect("it to parse as a valid uri");
 
-            assert_eq!(result.to_string(), uri)
+            assert_eq!(result.to_string(), uri);
         }
     }
 }

--- a/hitt-parser/src/variables/mod.rs
+++ b/hitt-parser/src/variables/mod.rs
@@ -1,0 +1,95 @@
+pub fn parse_variable_declaration(
+    chars: &mut core::iter::Enumerate<core::str::Chars>,
+) -> Option<(String, String)> {
+    let mut declaration = String::new();
+
+    let mut value = String::new();
+
+    let mut is_declaration = true;
+
+    for (_, ch) in chars {
+        if ch == '=' && is_declaration {
+            is_declaration = false;
+        } else if is_declaration {
+            declaration.push(ch);
+        } else {
+            value.push(ch);
+        }
+    }
+
+    if is_declaration {
+        return None;
+    }
+
+    Some((declaration.trim().to_owned(), value.trim().to_owned()))
+}
+
+#[cfg(test)]
+mod test_parse_variable_declarations {
+    use super::parse_variable_declaration;
+
+    #[test]
+    fn it_should_parse_variable_declarations() {
+        for i in 0..10 {
+            let input_declaration = format!("var{i}");
+            let input_value = format!("{i}");
+
+            // NOTE: we do not start with a '@' here since it is expected to already be removed
+            let input = format!("{input_declaration}={input_value}");
+
+            match parse_variable_declaration(&mut input.chars().enumerate()) {
+                Some((key, value)) => {
+                    assert_eq!(input_declaration, key);
+                    assert_eq!(input_value, value);
+                }
+
+                None => panic!(""),
+            }
+        }
+    }
+
+    #[test]
+    fn it_should_trim_spaces() {
+        let mut extra_spaces = String::new();
+
+        for i in 0..10 {
+            extra_spaces.push(' ');
+
+            let input_declaration = format!("var{i}");
+            let input_value = format!("{i}");
+
+            // NOTE: we do not start with a '@' here since it is expected to already be removed
+            let input = format!(
+                "{input_declaration}{extra_spaces}={extra_spaces}{input_value}{extra_spaces}"
+            );
+
+            match parse_variable_declaration(&mut input.chars().enumerate()) {
+                Some((key, value)) => {
+                    assert_eq!(input_declaration, key);
+                    assert_eq!(input_value, value);
+                }
+
+                None => panic!(""),
+            }
+        }
+    }
+}
+
+pub enum MaybeVariable {
+    Variable(String),
+    Text(String),
+}
+
+#[inline]
+pub fn parse_variable(chars: &mut core::iter::Enumerate<core::str::Chars>) -> MaybeVariable {
+    todo!()
+}
+
+#[cfg(test)]
+mod test_maybe_parse_variable {
+    #[test]
+    fn it_should_parse_variables() {}
+
+    #[test]
+    fn it_should_ignore_non_variables() {}
+}

--- a/hitt-parser/src/variables/mod.rs
+++ b/hitt-parser/src/variables/mod.rs
@@ -1,3 +1,4 @@
+#[inline]
 pub fn parse_variable_declaration(
     chars: &mut core::iter::Enumerate<core::str::Chars>,
 ) -> Option<(String, String)> {

--- a/hitt-parser/src/variables/mod.rs
+++ b/hitt-parser/src/variables/mod.rs
@@ -32,7 +32,7 @@ mod test_parse_variable_declarations {
 
     #[test]
     fn it_should_parse_variable_declarations() {
-        for i in 0..10 {
+        for i in 0..1337 {
             let input_declaration = format!("var{i}");
             let input_value = format!("{i}");
 
@@ -54,7 +54,7 @@ mod test_parse_variable_declarations {
     fn it_should_trim_spaces() {
         let mut extra_spaces = String::new();
 
-        for i in 0..10 {
+        for i in 0..1337 {
             extra_spaces.push(' ');
 
             let input_declaration = format!("var{i}");
@@ -83,7 +83,7 @@ pub fn parse_variable(
 ) -> Option<(String, usize)> {
     let mut jumps = 0;
 
-    if let Some((_, '{')) = &chars.next() {
+    if let Some((_, '{')) = chars.next() {
         jumps += 1;
         let mut x = String::new();
 
@@ -97,7 +97,7 @@ pub fn parse_variable(
             }
 
             if ch == '}' {
-                if let Some((_, '}')) = &chars.next() {
+                if let Some((_, '}')) = chars.next() {
                     if x.is_empty() {
                         return None;
                     }
@@ -135,7 +135,7 @@ mod test_maybe_parse_variable {
         let before = "{";
         let after = "}}";
 
-        for i in 0..100 {
+        for i in 0..1337 {
             let input_name = format!("name{i}");
 
             // NOTE: the first '{' was consumed by the caller
@@ -158,7 +158,7 @@ mod test_maybe_parse_variable {
         let before = "{";
         let after = "}}";
 
-        for i in 0..100 {
+        for i in 0..1337 {
             extra_whitespace.push(' ');
 
             let input_name = format!("name{i}");

--- a/hitt-parser/src/variables/mod.rs
+++ b/hitt-parser/src/variables/mod.rs
@@ -51,14 +51,14 @@ mod test_parse_variable_declarations {
     }
 
     #[test]
-    fn it_should_trim_spaces() {
+    fn it_should_allow_emails() {
         let mut extra_spaces = String::new();
 
         for i in i8::MIN..i8::MAX {
             extra_spaces.push(' ');
 
             let input_declaration = format!("var{i}");
-            let input_value = format!("{i}");
+            let input_value = format!("mads{i}@mhouge.dk");
 
             // NOTE: we do not start with a '@' here since it is expected to already be removed
             let input = format!(
@@ -71,7 +71,7 @@ mod test_parse_variable_declarations {
                     assert_eq!(input_value, value);
                 }
 
-                None => panic!(""),
+                None => panic!("it should return a variable declaration"),
             }
         }
     }

--- a/hitt-parser/src/variables/mod.rs
+++ b/hitt-parser/src/variables/mod.rs
@@ -26,6 +26,8 @@ pub fn parse_variable_declaration(
 
 #[cfg(test)]
 mod test_parse_variable_declarations {
+    use crate::to_enum_chars;
+
     use super::parse_variable_declaration;
 
     #[test]
@@ -37,7 +39,7 @@ mod test_parse_variable_declarations {
             // NOTE: we do not start with a '@' here since it is expected to already be removed
             let input = format!("{input_declaration}={input_value}");
 
-            match parse_variable_declaration(&mut input.chars().enumerate()) {
+            match parse_variable_declaration(&mut to_enum_chars(&input)) {
                 Some((key, value)) => {
                     assert_eq!(input_declaration, key);
                     assert_eq!(input_value, value);
@@ -63,7 +65,7 @@ mod test_parse_variable_declarations {
                 "{input_declaration}{extra_spaces}={extra_spaces}{input_value}{extra_spaces}"
             );
 
-            match parse_variable_declaration(&mut input.chars().enumerate()) {
+            match parse_variable_declaration(&mut to_enum_chars(&input)) {
                 Some((key, value)) => {
                     assert_eq!(input_declaration, key);
                     assert_eq!(input_value, value);
@@ -124,6 +126,8 @@ pub fn parse_variable(
 
 #[cfg(test)]
 mod test_maybe_parse_variable {
+    use crate::to_enum_chars;
+
     use super::parse_variable;
 
     #[test]
@@ -137,7 +141,7 @@ mod test_maybe_parse_variable {
             // NOTE: the first '{' was consumed by the caller
             let input = format!("{before}{input_name}{after}");
 
-            match parse_variable(&mut input.chars().enumerate()) {
+            match parse_variable(&mut to_enum_chars(&input)) {
                 Some((output_name, jumps)) => {
                     assert_eq!(input_name, output_name);
                     assert_eq!(input.len(), jumps);
@@ -162,7 +166,7 @@ mod test_maybe_parse_variable {
             // NOTE: the first '{' was consumed by the caller
             let input = format!("{before}{extra_whitespace}{input_name}{extra_whitespace}{after}");
 
-            match parse_variable(&mut input.chars().enumerate()) {
+            match parse_variable(&mut to_enum_chars(&input)) {
                 Some((output_name, jumps)) => {
                     assert_eq!(input_name, output_name);
                     assert_eq!(input.len(), jumps);
@@ -200,7 +204,7 @@ mod test_maybe_parse_variable {
         ];
 
         for input in inputs {
-            if let Some((var, jumps)) = parse_variable(&mut input.chars().enumerate()) {
+            if let Some((var, jumps)) = parse_variable(&mut to_enum_chars(input)) {
                 panic!("expected None but received '{var}' {jumps}' from '{input}''");
             }
         }

--- a/hitt-parser/src/variables/mod.rs
+++ b/hitt-parser/src/variables/mod.rs
@@ -32,7 +32,7 @@ mod test_parse_variable_declarations {
 
     #[test]
     fn it_should_parse_variable_declarations() {
-        for i in 0..1337 {
+        for i in i8::MIN..i8::MAX {
             let input_declaration = format!("var{i}");
             let input_value = format!("{i}");
 
@@ -45,7 +45,7 @@ mod test_parse_variable_declarations {
                     assert_eq!(input_value, value);
                 }
 
-                None => panic!(""),
+                None => panic!("it should return a valid string"),
             }
         }
     }
@@ -54,7 +54,7 @@ mod test_parse_variable_declarations {
     fn it_should_trim_spaces() {
         let mut extra_spaces = String::new();
 
-        for i in 0..1337 {
+        for i in i8::MIN..i8::MAX {
             extra_spaces.push(' ');
 
             let input_declaration = format!("var{i}");
@@ -104,9 +104,9 @@ pub fn parse_variable(
 
                     jumps += 1;
                     return Some((x, jumps));
-                } else {
-                    return None;
                 }
+
+                return None;
             }
 
             if ch.is_whitespace() {
@@ -135,7 +135,7 @@ mod test_maybe_parse_variable {
         let before = "{";
         let after = "}}";
 
-        for i in 0..1337 {
+        for i in i8::MIN..i8::MAX {
             let input_name = format!("name{i}");
 
             // NOTE: the first '{' was consumed by the caller
@@ -158,7 +158,7 @@ mod test_maybe_parse_variable {
         let before = "{";
         let after = "}}";
 
-        for i in 0..1337 {
+        for i in i8::MIN..i8::MAX {
             extra_whitespace.push(' ');
 
             let input_name = format!("name{i}");

--- a/hitt-parser/src/variables/mod.rs
+++ b/hitt-parser/src/variables/mod.rs
@@ -77,17 +77,17 @@ mod test_parse_variable_declarations {
 
 #[inline]
 pub fn parse_variable(
-    char_clone: &mut core::iter::Enumerate<core::str::Chars>,
+    chars: &mut core::iter::Enumerate<core::str::Chars>,
 ) -> Option<(String, usize)> {
     let mut jumps = 0;
 
-    if let Some((_, '{')) = &char_clone.next() {
+    if let Some((_, '{')) = &chars.next() {
         jumps += 1;
         let mut x = String::new();
 
         let mut is_key = true;
 
-        while let Some((_, ch)) = char_clone.next() {
+        while let Some((_, ch)) = chars.next() {
             jumps += 1;
 
             if ch == '{' {
@@ -95,7 +95,11 @@ pub fn parse_variable(
             }
 
             if ch == '}' {
-                if let Some((_, '}')) = &char_clone.next() {
+                if let Some((_, '}')) = &chars.next() {
+                    if x.is_empty() {
+                        return None;
+                    }
+
                     jumps += 1;
                     return Some((x, jumps));
                 } else {

--- a/hitt-parser/src/version/mod.rs
+++ b/hitt-parser/src/version/mod.rs
@@ -1,17 +1,34 @@
+use crate::variables::parse_variable;
+
 #[inline]
 pub fn parse_http_version(
     chars: &mut core::iter::Enumerate<core::str::Chars>,
-    _vars: &std::collections::HashMap<String, String>,
+    vars: &std::collections::HashMap<String, String>,
 ) -> Option<http::version::Version> {
     let mut version = String::new();
 
-    for (_, ch) in chars {
+    while let Some((_, ch)) = chars.next() {
         if ch.is_whitespace() {
             if !version.is_empty() {
                 break;
             }
 
             continue;
+        } else if ch == '{' {
+            // FIXME: remove clone
+            if let Some((var, jumps)) = parse_variable(&mut chars.clone()) {
+                if let Some(var_value) = vars.get(&var) {
+                    version.push_str(var_value);
+
+                    for _ in 0..jumps {
+                        chars.next();
+                    }
+
+                    continue;
+                } else {
+                    // NOTE: should this raise?
+                }
+            }
         }
 
         version.push(ch);
@@ -21,7 +38,7 @@ pub fn parse_http_version(
         return None;
     }
 
-    match version.to_lowercase().as_str() {
+    match version.to_lowercase().trim() {
         "http/0.9" => Some(http::Version::HTTP_09),
         "http/1.0" | "http/1" => Some(http::Version::HTTP_10),
         "http/1.1" => Some(http::Version::HTTP_11),
@@ -40,11 +57,11 @@ mod test_parse_http_version {
     static EMPTY_VARS: Lazy<std::collections::HashMap<String, String>> =
         Lazy::new(std::collections::HashMap::new);
 
+    const HTTP_0_9_INPUTS: [&str; 4] = ["HTTP/0.9", "   HTTP/0.9", "HTTP/0.9   ", "   HTTP/0.9   "];
+
     #[test]
     fn it_should_parse_http_0_9() {
-        let inputs = ["HTTP/0.9", "   HTTP/0.9", "HTTP/0.9   ", "   HTTP/0.9   "];
-
-        for input in inputs {
+        for input in HTTP_0_9_INPUTS {
             let uppercase_result = parse_http_version(&mut to_enum_chars(input), &EMPTY_VARS)
                 .expect("it to return a http version");
 
@@ -58,20 +75,20 @@ mod test_parse_http_version {
         }
     }
 
+    const HTTP_1_0_INPUTS: [&str; 8] = [
+        "HTTP/1",
+        "   HTTP/1",
+        "HTTP/1   ",
+        "   HTTP/1   ",
+        "HTTP/1.0",
+        "   HTTP/1.0",
+        "HTTP/1.0   ",
+        "   HTTP/1.0   ",
+    ];
+
     #[test]
     fn it_should_parse_http_1_0() {
-        let inputs = [
-            "HTTP/1",
-            "   HTTP/1",
-            "HTTP/1   ",
-            "   HTTP/1   ",
-            "HTTP/1.0",
-            "   HTTP/1.0",
-            "HTTP/1.0   ",
-            "   HTTP/1.0   ",
-        ];
-
-        for input in inputs {
+        for input in HTTP_1_0_INPUTS {
             let uppercase_result = parse_http_version(&mut to_enum_chars(input), &EMPTY_VARS)
                 .expect("it to return a http version");
 
@@ -85,12 +102,12 @@ mod test_parse_http_version {
         }
     }
 
+    // NOTE: should HTTP/1 mean the same as HTTP/1.1?
+    const HTTP_1_1_INPUTS: [&str; 4] = ["HTTP/1.1", "   HTTP/1.1", "HTTP/1.1   ", "   HTTP/1.1   "];
+
     #[test]
     fn it_should_parse_http_1_1() {
-        // NOTE: should HTTP/1 mean the same as HTTP/1.1?
-        let inputs = ["HTTP/1.1", "   HTTP/1.1", "HTTP/1.1   ", "   HTTP/1.1   "];
-
-        for input in inputs {
+        for input in HTTP_1_1_INPUTS {
             let uppercase_result = parse_http_version(&mut to_enum_chars(input), &EMPTY_VARS)
                 .expect("it to return a http version");
 
@@ -104,20 +121,20 @@ mod test_parse_http_version {
         }
     }
 
+    const HTTP_2_0_INPUTS: [&str; 8] = [
+        "HTTP/2",
+        "   HTTP/2",
+        "HTTP/2   ",
+        "   HTTP/2   ",
+        "HTTP/2.0",
+        "   HTTP/2.0",
+        "HTTP/2.0   ",
+        "   HTTP/2.0   ",
+    ];
+
     #[test]
     fn it_should_parse_http_2_0() {
-        let inputs = [
-            "HTTP/2",
-            "   HTTP/2",
-            "HTTP/2   ",
-            "   HTTP/2   ",
-            "HTTP/2.0",
-            "   HTTP/2.0",
-            "HTTP/2.0   ",
-            "   HTTP/2.0   ",
-        ];
-
-        for input in inputs {
+        for input in HTTP_2_0_INPUTS {
             let uppercase_result = parse_http_version(&mut to_enum_chars(input), &EMPTY_VARS)
                 .expect("it to return a http version");
 
@@ -131,20 +148,20 @@ mod test_parse_http_version {
         }
     }
 
+    const HTTP_3_0_INPUTS: [&str; 8] = [
+        "HTTP/3",
+        "   HTTP/3",
+        "HTTP/3   ",
+        "   HTTP/3   ",
+        "HTTP/3.0",
+        "   HTTP/3.0",
+        "HTTP/3.0   ",
+        "   HTTP/3.0   ",
+    ];
+
     #[test]
     fn it_should_parse_http_3_0() {
-        let inputs = [
-            "HTTP/3",
-            "   HTTP/3",
-            "HTTP/3   ",
-            "   HTTP/3   ",
-            "HTTP/3.0",
-            "   HTTP/3.0",
-            "HTTP/3.0   ",
-            "   HTTP/3.0   ",
-        ];
-
-        for input in inputs {
+        for input in HTTP_3_0_INPUTS {
             let uppercase_result = parse_http_version(&mut to_enum_chars(input), &EMPTY_VARS)
                 .expect("it to return a http version");
 
@@ -155,6 +172,81 @@ mod test_parse_http_version {
                     .expect("it to return a http version");
 
             assert_eq!(http::Version::HTTP_3, lowercase_result);
+        }
+    }
+
+    #[test]
+    fn it_should_support_variables() {
+        let mut vars = std::collections::HashMap::new();
+
+        for version in HTTP_0_9_INPUTS {
+            vars.insert("version".to_owned(), version.to_owned());
+
+            assert_eq!(
+                Some(http::Version::HTTP_09),
+                parse_http_version(&mut to_enum_chars("{{version}}"), &vars)
+            );
+
+            assert_eq!(
+                Some(http::Version::HTTP_09),
+                parse_http_version(&mut to_enum_chars("{{  version  }}"), &vars)
+            );
+        }
+
+        for version in HTTP_1_0_INPUTS {
+            vars.insert("version".to_owned(), version.to_owned());
+
+            assert_eq!(
+                Some(http::Version::HTTP_10),
+                parse_http_version(&mut to_enum_chars("{{version}}"), &vars)
+            );
+
+            assert_eq!(
+                Some(http::Version::HTTP_10),
+                parse_http_version(&mut to_enum_chars("{{  version  }}"), &vars)
+            );
+        }
+
+        for version in HTTP_1_1_INPUTS {
+            vars.insert("version".to_owned(), version.to_owned());
+
+            assert_eq!(
+                Some(http::Version::HTTP_11),
+                parse_http_version(&mut to_enum_chars("{{version}}"), &vars)
+            );
+
+            assert_eq!(
+                Some(http::Version::HTTP_11),
+                parse_http_version(&mut to_enum_chars("{{  version  }}"), &vars)
+            );
+        }
+
+        for version in HTTP_2_0_INPUTS {
+            vars.insert("version".to_owned(), version.to_owned());
+
+            assert_eq!(
+                Some(http::Version::HTTP_2),
+                parse_http_version(&mut to_enum_chars("{{version}}"), &vars)
+            );
+
+            assert_eq!(
+                Some(http::Version::HTTP_2),
+                parse_http_version(&mut to_enum_chars("{{  version  }}"), &vars)
+            );
+        }
+
+        for version in HTTP_3_0_INPUTS {
+            vars.insert("version".to_owned(), version.to_owned());
+
+            assert_eq!(
+                Some(http::Version::HTTP_3),
+                parse_http_version(&mut to_enum_chars("{{version}}"), &vars)
+            );
+
+            assert_eq!(
+                Some(http::Version::HTTP_3),
+                parse_http_version(&mut to_enum_chars("{{  version  }}"), &vars)
+            );
         }
     }
 }

--- a/hitt-parser/src/version/mod.rs
+++ b/hitt-parser/src/version/mod.rs
@@ -38,7 +38,7 @@ mod test_parse_http_version {
     fn it_should_parse_http_0_9() {
         let input = ["HTTP/0.9", "   HTTP/0.9", "HTTP/0.9   ", "   HTTP/0.9   "];
 
-        input.iter().for_each(|s| {
+        for s in input {
             let uppercase_result = parse_http_version(&mut s.chars().enumerate())
                 .expect("it to return a http version");
 
@@ -48,7 +48,7 @@ mod test_parse_http_version {
                 .expect("it to return a http version");
 
             assert_eq!(http::Version::HTTP_09, lowercase_result);
-        });
+        }
     }
 
     #[test]
@@ -64,7 +64,7 @@ mod test_parse_http_version {
             "   HTTP/1.0   ",
         ];
 
-        input.iter().for_each(|s| {
+        for s in input {
             let uppercase_result = parse_http_version(&mut s.chars().enumerate())
                 .expect("it to return a http version");
 
@@ -74,7 +74,7 @@ mod test_parse_http_version {
                 .expect("it to return a http version");
 
             assert_eq!(http::Version::HTTP_10, lowercase_result);
-        });
+        }
     }
 
     #[test]
@@ -82,7 +82,7 @@ mod test_parse_http_version {
         // NOTE: should HTTP/1 mean the same as HTTP/1.1?
         let input = ["HTTP/1.1", "   HTTP/1.1", "HTTP/1.1   ", "   HTTP/1.1   "];
 
-        input.iter().for_each(|s| {
+        for s in input {
             let uppercase_result = parse_http_version(&mut s.chars().enumerate())
                 .expect("it to return a http version");
 
@@ -92,7 +92,7 @@ mod test_parse_http_version {
                 .expect("it to return a http version");
 
             assert_eq!(http::Version::HTTP_11, lowercase_result);
-        });
+        }
     }
 
     #[test]
@@ -108,7 +108,7 @@ mod test_parse_http_version {
             "   HTTP/2.0   ",
         ];
 
-        input.iter().for_each(|s| {
+        for s in input {
             let uppercase_result = parse_http_version(&mut s.chars().enumerate())
                 .expect("it to return a http version");
 
@@ -118,7 +118,7 @@ mod test_parse_http_version {
                 .expect("it to return a http version");
 
             assert_eq!(http::Version::HTTP_2, lowercase_result);
-        });
+        }
     }
 
     #[test]
@@ -134,7 +134,7 @@ mod test_parse_http_version {
             "   HTTP/3.0   ",
         ];
 
-        input.iter().for_each(|s| {
+        for s in input {
             let uppercase_result = parse_http_version(&mut s.chars().enumerate())
                 .expect("it to return a http version");
 
@@ -144,6 +144,6 @@ mod test_parse_http_version {
                 .expect("it to return a http version");
 
             assert_eq!(http::Version::HTTP_3, lowercase_result);
-        });
+        }
     }
 }

--- a/hitt-parser/src/version/mod.rs
+++ b/hitt-parser/src/version/mod.rs
@@ -25,9 +25,9 @@ pub fn parse_http_version(
                     }
 
                     continue;
-                } else {
-                    // NOTE: should this raise?
                 }
+
+                // NOTE: should variable not existing raise an error?
             }
         }
 

--- a/hitt-parser/src/version/mod.rs
+++ b/hitt-parser/src/version/mod.rs
@@ -1,6 +1,7 @@
 #[inline]
 pub fn parse_http_version(
     chars: &mut core::iter::Enumerate<core::str::Chars>,
+    _vars: &std::collections::HashMap<String, String>,
 ) -> Option<http::version::Version> {
     let mut version = String::new();
 
@@ -32,20 +33,26 @@ pub fn parse_http_version(
 
 #[cfg(test)]
 mod test_parse_http_version {
-    use crate::version::parse_http_version;
+    use once_cell::sync::Lazy;
+
+    use crate::{to_enum_chars, version::parse_http_version};
+
+    static EMPTY_VARS: Lazy<std::collections::HashMap<String, String>> =
+        Lazy::new(std::collections::HashMap::new);
 
     #[test]
     fn it_should_parse_http_0_9() {
-        let input = ["HTTP/0.9", "   HTTP/0.9", "HTTP/0.9   ", "   HTTP/0.9   "];
+        let inputs = ["HTTP/0.9", "   HTTP/0.9", "HTTP/0.9   ", "   HTTP/0.9   "];
 
-        for s in input {
-            let uppercase_result = parse_http_version(&mut s.chars().enumerate())
+        for input in inputs {
+            let uppercase_result = parse_http_version(&mut to_enum_chars(input), &EMPTY_VARS)
                 .expect("it to return a http version");
 
             assert_eq!(http::Version::HTTP_09, uppercase_result);
 
-            let lowercase_result = parse_http_version(&mut s.to_lowercase().chars().enumerate())
-                .expect("it to return a http version");
+            let lowercase_result =
+                parse_http_version(&mut to_enum_chars(&input.to_lowercase()), &EMPTY_VARS)
+                    .expect("it to return a http version");
 
             assert_eq!(http::Version::HTTP_09, lowercase_result);
         }
@@ -53,7 +60,7 @@ mod test_parse_http_version {
 
     #[test]
     fn it_should_parse_http_1_0() {
-        let input = [
+        let inputs = [
             "HTTP/1",
             "   HTTP/1",
             "HTTP/1   ",
@@ -64,14 +71,15 @@ mod test_parse_http_version {
             "   HTTP/1.0   ",
         ];
 
-        for s in input {
-            let uppercase_result = parse_http_version(&mut s.chars().enumerate())
+        for input in inputs {
+            let uppercase_result = parse_http_version(&mut to_enum_chars(input), &EMPTY_VARS)
                 .expect("it to return a http version");
 
             assert_eq!(http::Version::HTTP_10, uppercase_result);
 
-            let lowercase_result = parse_http_version(&mut s.to_lowercase().chars().enumerate())
-                .expect("it to return a http version");
+            let lowercase_result =
+                parse_http_version(&mut to_enum_chars(&input.to_lowercase()), &EMPTY_VARS)
+                    .expect("it to return a http version");
 
             assert_eq!(http::Version::HTTP_10, lowercase_result);
         }
@@ -80,16 +88,17 @@ mod test_parse_http_version {
     #[test]
     fn it_should_parse_http_1_1() {
         // NOTE: should HTTP/1 mean the same as HTTP/1.1?
-        let input = ["HTTP/1.1", "   HTTP/1.1", "HTTP/1.1   ", "   HTTP/1.1   "];
+        let inputs = ["HTTP/1.1", "   HTTP/1.1", "HTTP/1.1   ", "   HTTP/1.1   "];
 
-        for s in input {
-            let uppercase_result = parse_http_version(&mut s.chars().enumerate())
+        for input in inputs {
+            let uppercase_result = parse_http_version(&mut to_enum_chars(input), &EMPTY_VARS)
                 .expect("it to return a http version");
 
             assert_eq!(http::Version::HTTP_11, uppercase_result);
 
-            let lowercase_result = parse_http_version(&mut s.to_lowercase().chars().enumerate())
-                .expect("it to return a http version");
+            let lowercase_result =
+                parse_http_version(&mut to_enum_chars(&input.to_lowercase()), &EMPTY_VARS)
+                    .expect("it to return a http version");
 
             assert_eq!(http::Version::HTTP_11, lowercase_result);
         }
@@ -97,7 +106,7 @@ mod test_parse_http_version {
 
     #[test]
     fn it_should_parse_http_2_0() {
-        let input = [
+        let inputs = [
             "HTTP/2",
             "   HTTP/2",
             "HTTP/2   ",
@@ -108,14 +117,15 @@ mod test_parse_http_version {
             "   HTTP/2.0   ",
         ];
 
-        for s in input {
-            let uppercase_result = parse_http_version(&mut s.chars().enumerate())
+        for input in inputs {
+            let uppercase_result = parse_http_version(&mut to_enum_chars(input), &EMPTY_VARS)
                 .expect("it to return a http version");
 
             assert_eq!(http::Version::HTTP_2, uppercase_result);
 
-            let lowercase_result = parse_http_version(&mut s.to_lowercase().chars().enumerate())
-                .expect("it to return a http version");
+            let lowercase_result =
+                parse_http_version(&mut to_enum_chars(&input.to_lowercase()), &EMPTY_VARS)
+                    .expect("it to return a http version");
 
             assert_eq!(http::Version::HTTP_2, lowercase_result);
         }
@@ -123,7 +133,7 @@ mod test_parse_http_version {
 
     #[test]
     fn it_should_parse_http_3_0() {
-        let input = [
+        let inputs = [
             "HTTP/3",
             "   HTTP/3",
             "HTTP/3   ",
@@ -134,14 +144,15 @@ mod test_parse_http_version {
             "   HTTP/3.0   ",
         ];
 
-        for s in input {
-            let uppercase_result = parse_http_version(&mut s.chars().enumerate())
+        for input in inputs {
+            let uppercase_result = parse_http_version(&mut to_enum_chars(input), &EMPTY_VARS)
                 .expect("it to return a http version");
 
             assert_eq!(http::Version::HTTP_3, uppercase_result);
 
-            let lowercase_result = parse_http_version(&mut s.to_lowercase().chars().enumerate())
-                .expect("it to return a http version");
+            let lowercase_result =
+                parse_http_version(&mut to_enum_chars(&input.to_lowercase()), &EMPTY_VARS)
+                    .expect("it to return a http version");
 
             assert_eq!(http::Version::HTTP_3, lowercase_result);
         }

--- a/hitt-parser/src/version/mod.rs
+++ b/hitt-parser/src/version/mod.rs
@@ -1,5 +1,5 @@
 #[inline]
-pub(super) fn parse_http_version(
+pub fn parse_http_version(
     chars: &mut core::iter::Enumerate<core::str::Chars>,
 ) -> Option<http::version::Version> {
     let mut version = String::new();
@@ -48,7 +48,7 @@ mod test_parse_http_version {
                 .expect("it to return a http version");
 
             assert_eq!(http::Version::HTTP_09, lowercase_result);
-        })
+        });
     }
 
     #[test]
@@ -74,7 +74,7 @@ mod test_parse_http_version {
                 .expect("it to return a http version");
 
             assert_eq!(http::Version::HTTP_10, lowercase_result);
-        })
+        });
     }
 
     #[test]
@@ -92,7 +92,7 @@ mod test_parse_http_version {
                 .expect("it to return a http version");
 
             assert_eq!(http::Version::HTTP_11, lowercase_result);
-        })
+        });
     }
 
     #[test]
@@ -118,7 +118,7 @@ mod test_parse_http_version {
                 .expect("it to return a http version");
 
             assert_eq!(http::Version::HTTP_2, lowercase_result);
-        })
+        });
     }
 
     #[test]
@@ -144,6 +144,6 @@ mod test_parse_http_version {
                 .expect("it to return a http version");
 
             assert_eq!(http::Version::HTTP_3, lowercase_result);
-        })
+        });
     }
 }


### PR DESCRIPTION
The goal of this PR is to implement basic support for variable declarations and usage.

- [x] variable declarations
- [x] variables in http method
- [x] variables in uri
- [x] variables in http version
- [x] variable in header keys
- [x] variables header values
- [x] variables in body

# Variable declaration

```
@method = GET
@host = https://mhouge.dk
@path = /api
@query_value = value
```

# Usage

```
{{method}} {{host}}{{path}}?key={{query_value}}
```

should be interpreted as

```
GET https://mhouge.dk/api?key=query_value
```

Will close #3 on merge.
