### PR TITLE
refactor: copy small enums

### DIFF
--- a/hitt-cli/src/commands/new.rs
+++ b/hitt-cli/src/commands/new.rs
@@ -111,9 +111,9 @@ fn save_request(
         }
     }
 
-    if let Some(body) = body {
+    if let Some(content) = body {
         contents.push('\n');
-        contents.push_str(&body);
+        contents.push_str(&content);
         contents.push('\n');
     }
 

--- a/hitt-cli/src/terminal/body.rs
+++ b/hitt-cli/src/terminal/body.rs
@@ -11,7 +11,7 @@ fn __print_body(term: &console::Term, body: &str) -> Result<(), std::io::Error> 
 pub(crate) fn print_body(
     term: &console::Term,
     body: &str,
-    content_type: &ContentType,
+    content_type: ContentType,
     disable_pretty_printing: bool,
 ) -> Result<(), std::io::Error> {
     if disable_pretty_printing {

--- a/hitt-cli/src/terminal/mod.rs
+++ b/hitt-cli/src/terminal/mod.rs
@@ -31,7 +31,7 @@ pub(crate) fn handle_response(
 ) -> Result<(), HittCliError> {
     print_status(
         term,
-        &response.http_version,
+        response.http_version,
         &response.method,
         &response.url,
         response.status_code.as_u16(),
@@ -50,7 +50,7 @@ pub(crate) fn handle_response(
                 ContentType::from(value.to_str().unwrap_or_default())
             });
 
-        print_body(term, &response.body, &content_type, args.disable_formatting)?;
+        print_body(term, &response.body, content_type, args.disable_formatting)?;
     }
 
     if args.fail_fast

--- a/hitt-cli/src/terminal/status.rs
+++ b/hitt-cli/src/terminal/status.rs
@@ -3,7 +3,7 @@ use crate::terminal::{STYLE_BOLD, STYLE_RESET, TEXT_GREEN, TEXT_RED, TEXT_RESET}
 #[inline]
 pub(crate) fn print_status(
     term: &console::Term,
-    http_version: &http::version::Version,
+    http_version: http::version::Version,
     method: &str,
     url: &str,
     status_code: u16,

--- a/hitt-formatter/src/lib.rs
+++ b/hitt-formatter/src/lib.rs
@@ -2,6 +2,7 @@ use json::format_json;
 
 pub mod json;
 
+#[derive(Copy, Clone)]
 pub enum ContentType {
     Json,
     Unknown,
@@ -19,7 +20,7 @@ impl From<&str> for ContentType {
 }
 
 #[inline]
-pub fn format(input: &str, content_type: &ContentType) -> Option<String> {
+pub fn format(input: &str, content_type: ContentType) -> Option<String> {
     match content_type {
         ContentType::Json => Some(format_json(input)),
         ContentType::Unknown => None,


### PR DESCRIPTION
The small enums have a lower overhead in bytes than a pointer, so copying is better