### PR TITLE
refactor(cli): explicit variable indexing errors

### DIFF
--- a/hitt-cli/src/config/variables.rs
+++ b/hitt-cli/src/config/variables.rs
@@ -5,11 +5,15 @@ pub fn parse_variable_argument(argument: &str) -> Result<(String, String), HittC
         .find('=')
         .ok_or_else(|| HittCliError::InvalidVariableArgument(argument.to_owned()))?;
 
-    let key = argument.get(..pos).unwrap().to_owned();
+    let key = argument
+        .get(..pos)
+        .ok_or_else(|| HittCliError::VariableArgumentKeyIndexing(argument.to_owned()))?;
 
-    let val = argument.get(pos + 1..).unwrap().to_owned();
+    let val = argument
+        .get(pos + 1..)
+        .ok_or_else(|| HittCliError::VariableArgumentValueIndexing(argument.to_owned()))?;
 
-    Ok((key, val))
+    Ok((key.to_owned(), val.to_owned()))
 }
 
 #[cfg(test)]

--- a/hitt-cli/src/error/mod.rs
+++ b/hitt-cli/src/error/mod.rs
@@ -12,6 +12,8 @@ pub enum HittCliError {
     Reqwest(http::Method, http::Uri, reqwest::Error),
     RequestTimeout(http::Method, http::Uri),
     InvalidVariableArgument(String),
+    VariableArgumentKeyIndexing(String),
+    VariableArgumentValueIndexing(String),
 }
 
 impl fmt::Display for HittCliError {
@@ -25,7 +27,15 @@ impl fmt::Display for HittCliError {
             Self::Io(error) => format!("io error {error:#?}"),
             Self::Reqwest(method, uri, error) => format!("{method} {uri} - {error}"),
             Self::RequestTimeout(method, uri) => format!("{method} {uri} - request timed out"),
-            Self::InvalidVariableArgument(input)=> format!("'{input}' is not a valid variable argument - variable input should be '--var <KEY>=<VALUE>'")
+            Self::InvalidVariableArgument(input) => {
+                format!("'{input}' is not a valid variable argument - variable input should be '--var <KEY>=<VALUE>'")
+            }
+            Self::VariableArgumentKeyIndexing(variable) => {
+                format!("unable to index key of --var '{variable}'")
+            }
+            Self::VariableArgumentValueIndexing(variable) => {
+                format!("unable to index value of --var '{variable}'")
+            }
         };
 
         write!(f, "{TEXT_RED}hitt: {error_message}{TEXT_RESET}")


### PR DESCRIPTION
Adds explicit indexing errors instead of calling unwrap