### PR TITLE
feat(parser): add support for variables in variable declaration

### DIFF
--- a/hitt-parser/src/lib.rs
+++ b/hitt-parser/src/lib.rs
@@ -80,7 +80,7 @@ fn tokenize(
                     // move forward once since we don't care about the '@'
                     chrs.next();
 
-                    if let Some((name, value)) = parse_variable_declaration(&mut chrs) {
+                    if let Some((name, value)) = parse_variable_declaration(&mut chrs, &vars)? {
                         vars.insert(name, value);
                         continue;
                     }


### PR DESCRIPTION
Added support for using variables in variable declaration values.

```
@hostname=localhost
@port=5000
@host={{hostname}}:{{port}}
GET {{host}}/users
```